### PR TITLE
Configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   advent!

--- a/README.md
+++ b/README.md
@@ -16,15 +16,26 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
+Create a config file that defines the root of your Advent of Code solutions:
+
+```
+mkdir /where/i/store/projects/advent_of_code
+cd advent_of_code
+
+touch advent.yml
+```
+
+Configuration values and format are explained in the [Config](#config) section.
+
 Advent expects you to have a working directory resembling something like:
 
     $ tree
     .
     ├── 2015
-    └── 2016
+    ├── 2016
+    └── advent.yml
 
-Some commands can be run from within a directory for a specific year, but it's
-better to run from the parent directory where possible.
+You can run commands from anywhere under this directory.
 
 The typical flow for tackling a daily challenge would be:
 
@@ -39,6 +50,32 @@ The typical flow for tackling a daily challenge would be:
 A list of commands and help is available using `advent`:
 
     $ advent help
+
+## Config
+
+The config file should be at the root of your working directory called
+`advent.yml`. The default values if you don't provide an override are:
+
+```yaml
+download_when_generating: true
+remember_session: true
+```
+
+### Config explained
+
+<dl>
+<dt>download_when_generating</dt>
+<dd>
+When you run `advent generate` it will automatically download the input file to
+go with it
+</dd>
+
+<dt>remember_session</dt>
+<dd>
+Save your session cookie in `.advent_session` when prompted so you don't need to
+find it again
+</dd>
+</dl>
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-Create a config file that defines the root of your Advent of Code solutions:
+Initialise a new project somewhere:
 
-```
-mkdir /where/i/store/projects/advent_of_code
-cd advent_of_code
+```bash
+mkdir advent_of_code && cd advent_of_code
 
-touch advent.yml
+# create a blank advent.yml config file
+advent init
 ```
 
 Configuration values and format are explained in the [Config](#config) section.

--- a/advent.gemspec
+++ b/advent.gemspec
@@ -19,4 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor", "~> 1.2"
+
+  spec.post_install_message = "
+advent v0.1.5 requires a config file in your working directory.
+
+See #{spec.homepage}/blob/main/README.md#usage or if you're
+brave run `advent init` in your current directory.
+
+"
 end

--- a/lib/advent.rb
+++ b/lib/advent.rb
@@ -11,6 +11,10 @@ module Advent
   class Error < StandardError; end
 
   class << self
+    def config
+      @_config ||= Configuration.from_file(root.join(Configuration::FILE_NAME))
+    end
+
     def root
       if (location = find_config_location)
         location
@@ -20,7 +24,7 @@ module Advent
     end
 
     def session
-      @_session = Session.new
+      @_session ||= Session.new
     end
 
     private

--- a/lib/advent.rb
+++ b/lib/advent.rb
@@ -11,8 +11,25 @@ module Advent
   class Error < StandardError; end
 
   class << self
+    def root
+      if (location = find_config_location)
+        location
+      else
+        raise Error, "Cannot find advent.yml config file in current or parent directories."
+      end
+    end
+
     def session
       @_session = Session.new
+    end
+
+    private
+
+    def find_config_location
+      Pathname.new(Dir.pwd).ascend do |path|
+        return path if File.exist? path.join(Configuration::FILE_NAME)
+        return nil if path.to_s == "/"
+      end
     end
   end
 end

--- a/lib/advent.rb
+++ b/lib/advent.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "advent/configuration"
 require_relative "advent/input"
 require_relative "advent/session"
 require_relative "advent/solution"

--- a/lib/advent/cli.rb
+++ b/lib/advent/cli.rb
@@ -51,6 +51,13 @@ module Advent
       download year, day if Advent.config.download_when_generating
     end
 
+    desc "init DIR", "Initialise a new advent project in DIR"
+    def init(dir = ".")
+      create_file Pathname.getwd.join(dir).join(Advent::Configuration::FILE_NAME) do
+        ""
+      end
+    end
+
     desc "solve FILE", "Solve your solution"
     # Runs a solution file, outputting both :part1 and :part2 method return values.
     def solve(path)

--- a/lib/advent/cli.rb
+++ b/lib/advent/cli.rb
@@ -9,13 +9,12 @@ module Advent
   class CLI < Thor
     include Thor::Actions
 
-    class_option :root_path, default: Dir.pwd, hide: true, check_default_type: false
     class_option :http_module, default: Net::HTTP, check_default_type: false
 
     def initialize(*args)
       super
 
-      self.destination_root = root_path
+      self.destination_root = Advent.root
       source_paths << File.expand_path("templates", __dir__)
     end
 
@@ -91,7 +90,11 @@ module Advent
     # Runs a solution file, outputting both :part1 and :part2 method return values.
     def solve(path)
       require "advent/cli/solver"
-      Solver.new(self, root_path.join(path)).solve
+      file_path = Pathname.getwd.join(path)
+
+      Dir.chdir Advent.root do
+        Solver.new(self, file_path.relative_path_from(Advent.root)).solve
+      end
     end
 
     desc "version", "Prints the current version of the gem"
@@ -107,14 +110,6 @@ module Advent
         [root_path.basename.to_s, parse_number(year_or_day)]
       else
         [year_or_day, parse_number(day)]
-      end
-    end
-
-    def root_path
-      @_root_path ||= if options.root_path.is_a?(Pathname)
-        options.root_path
-      else
-        Pathname.new(options.root_path)
       end
     end
 

--- a/lib/advent/cli.rb
+++ b/lib/advent/cli.rb
@@ -14,8 +14,12 @@ module Advent
     def initialize(*args)
       super
 
-      self.destination_root = Advent.root
       source_paths << File.expand_path("templates", __dir__)
+
+      # Don't try to load Advent.root if we're running init
+      unless args.last[:current_command]&.name == "init"
+        self.destination_root = Advent.root
+      end
     end
 
     # @return [Boolean] defines whether an exit status is set if a command fails

--- a/lib/advent/cli.rb
+++ b/lib/advent/cli.rb
@@ -47,6 +47,8 @@ module Advent
 
       template "solution.rb.tt", "#{year}/day#{day}.rb", context: binding
       template "solution_test.rb.tt", "#{year}/test/day#{day}_test.rb", context: binding
+
+      download year, day if Advent.config.download_when_generating
     end
 
     desc "solve FILE", "Solve your solution"

--- a/lib/advent/cli.rb
+++ b/lib/advent/cli.rb
@@ -23,15 +23,6 @@ module Advent
       true
     end
 
-    no_commands do
-      # @return [Boolean] whether the current root_path option is in a
-      # directory that looks like a year (eg. 2015)
-      def in_year_directory?
-        dir = root_path.basename.to_s
-        dir =~ /^20[0-9]{2}/
-      end
-    end
-
     desc "download YEAR DAY", "Download the input for YEAR and DAY"
     def download(year, day)
       require "advent/cli/downloader"
@@ -45,22 +36,17 @@ module Advent
     # Generates a new solution file. If within a year directory, only the day
     # is used, otherwise both the year and day will be required to generate the
     # output.
-    def generate(year_or_day, day = nil)
-      year, day = determine_year_and_day(year_or_day, day)
+    def generate(year, day)
+      year = parse_number year
+      day = parse_number day
 
-      if (error_message = validate(year, day))
-        say_error error_message, :red
+      if (message = validate(year, day))
+        say_error message, :red
         return
       end
 
-      subpath = if in_year_directory?
-        ""
-      else
-        "#{year}/"
-      end
-
-      template "solution.rb.tt", "#{subpath}day#{day}.rb", context: binding
-      template "solution_test.rb.tt", "#{subpath}test/day#{day}_test.rb", context: binding
+      template "solution.rb.tt", "#{year}/day#{day}.rb", context: binding
+      template "solution_test.rb.tt", "#{year}/test/day#{day}_test.rb", context: binding
     end
 
     desc "solve FILE", "Solve your solution"
@@ -81,14 +67,6 @@ module Advent
     end
 
     private
-
-    def determine_year_and_day(year_or_day, day)
-      if in_year_directory?
-        [root_path.basename.to_s, parse_number(year_or_day)]
-      else
-        [year_or_day, parse_number(day)]
-      end
-    end
 
     def parse_number(str)
       if (m = str.match(/[0-9]+/))

--- a/lib/advent/cli.rb
+++ b/lib/advent/cli.rb
@@ -33,34 +33,11 @@ module Advent
     end
 
     desc "download YEAR DAY", "Download the input for YEAR and DAY"
-    def download(year_or_day, day = nil)
-      year, day = determine_year_and_day(year_or_day, day)
+    def download(year, day)
+      require "advent/cli/downloader"
 
-      if (error_message = validate(year, day))
-        say_error error_message, :red
-        return
-      end
-
-      subpath = if in_year_directory?
-        ""
-      else
-        "#{year}/"
-      end
-
-      unless Advent.session.exist?
-        session = ask "What is your Advent of Code session cookie value?", echo: false
-        Advent.session.value = session
-
-        say "\n\nThanks. Psst, we're going to save this for next time. It's in .advent_session if you need to update or delete it.\n\n"
-      end
-
-      input = Advent::Input.new(root_path.join(subpath), day: day.to_i)
-
-      if input.download(Advent.session.value, options.http_module)
-        say "Input downloaded to #{input.file_path}.", :green
-        say "\nUsing #load_input in your daily solution will load the input file for you."
-      else
-        say_error "Something went wrong, maybe an old session cookie?", :red
+      Dir.chdir Advent.root do
+        Downloader.new(self, year, day).download
       end
     end
 

--- a/lib/advent/cli/downloader.rb
+++ b/lib/advent/cli/downloader.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Advent::CLI::Downloader
+  def initialize(command, year, day)
+    @command = command
+    @year = year
+    @day = day
+  end
+
+  def download
+    ask_for_session_cookie_if_needed
+    input = Advent::Input.new(Advent.root.join(@year), day: @day.to_i)
+
+    if input.download(Advent.session.value, @command.options.http_module)
+      @command.say "Input downloaded to #{input.file_path}.", :green
+      @command.say "\nUsing #load_input in your daily solution will load the input file for you."
+    else
+      @command.say_error "Something went wrong, maybe an old session cookie?", :red
+    end
+  end
+
+  private
+  
+  def ask_for_session_cookie_if_needed
+    return if Advent.session.exist?
+
+    session = @command.ask "What is your Advent of Code session cookie value?", echo: false
+    Advent.session.value = session
+
+    @command.say "\n\nThanks. Psst, we're going to save this for next time. It's in .advent_session if you need to update or delete it.\n\n"
+  end
+end

--- a/lib/advent/cli/downloader.rb
+++ b/lib/advent/cli/downloader.rb
@@ -20,7 +20,7 @@ class Advent::CLI::Downloader
   end
 
   private
-  
+
   def ask_for_session_cookie_if_needed
     return if Advent.session.exist?
 

--- a/lib/advent/cli/solver.rb
+++ b/lib/advent/cli/solver.rb
@@ -37,15 +37,11 @@ class Advent::CLI::Solver
 
   private
 
-  def day
-    @_day ||= @path.basename.to_s.match(/day([0-9]+)\.rb/)[1]
-  end
-
-  def solution_file_name
-    "day#{day}.rb"
-  end
-
   def solution_class_name
     "Day#{day}"
+  end
+
+  def day
+    @_day ||= @path.basename.to_s.match(/day([0-9]+)\.rb/)[1]
   end
 end

--- a/lib/advent/cli/solver.rb
+++ b/lib/advent/cli/solver.rb
@@ -18,7 +18,7 @@ class Advent::CLI::Solver
       load @path, Solutions
       solution = Solutions.const_get(solution_class_name).new
     else
-      require @path
+      require @path.expand_path
       solution = Object.const_get(solution_class_name).new
     end
 

--- a/lib/advent/configuration.rb
+++ b/lib/advent/configuration.rb
@@ -16,7 +16,9 @@ module Advent
       end
     end
 
-    def initialize(config = DEFAULTS)
+    def initialize(conf)
+      config = DEFAULTS.merge(conf || {})
+
       @download_when_generating = config.dig("download_when_generating")
       @remember_session = config.dig("remember_session")
     end

--- a/lib/advent/configuration.rb
+++ b/lib/advent/configuration.rb
@@ -1,0 +1,24 @@
+require "psych"
+
+module Advent
+  class Configuration
+    DEFAULTS = {
+      "download_when_generating" => true,
+      "remember_session" => true
+    }
+    FILE_NAME = "advent.yml"
+
+    attr_reader :download_when_generating, :remember_session
+
+    class << self
+      def from_file(file = FILE_NAME)
+        new Psych.safe_load_file(file)
+      end
+    end
+
+    def initialize(config = DEFAULTS)
+      @download_when_generating = config.dig("download_when_generating")
+      @remember_session = config.dig("remember_session")
+    end
+  end
+end

--- a/lib/advent/configuration.rb
+++ b/lib/advent/configuration.rb
@@ -12,7 +12,11 @@ module Advent
 
     class << self
       def from_file(file = FILE_NAME)
-        new Psych.safe_load_file(file)
+        if RUBY_VERSION >= "3.1"
+          new Psych.safe_load_file(file)
+        else
+          new Psych.safe_load(File.read(file))
+        end
       end
     end
 

--- a/lib/advent/session.rb
+++ b/lib/advent/session.rb
@@ -18,11 +18,22 @@ module Advent
     end
 
     def value=(val)
-      File.write file_name, val
+      if save_to_disk?
+        File.write file_name, val
+      else
+        @_value = val
+      end
     end
 
     def value
-      File.read file_name if exist?
+      return @_value unless save_to_disk?
+      return File.read(file_name) if exist?
+    end
+
+    private
+
+    def save_to_disk?
+      Advent.config.remember_session
     end
   end
 end

--- a/test/advent/cli_test.rb
+++ b/test/advent/cli_test.rb
@@ -61,7 +61,7 @@ class Advent::CLITest < Advent::TestCase
     assert_equal "Part 1: 789\nPart 2: Missing", out.strip
   end
 
-  def test_generate_solution_with_year_and_day
+  def test_generate
     capture_io do
       @cli.invoke(:generate, ["2015", "3"])
     end
@@ -74,9 +74,9 @@ class Advent::CLITest < Advent::TestCase
     end
   end
 
-  def test_generate_solution_from_year_directory_with_day
+  def test_generate_day_parsing
     capture_io do
-      @year_cli.invoke(:generate, ["3"])
+      @cli.invoke(:generate, ["2015", "day3"])
     end
 
     ["day3.rb", "test/day3_test.rb"].each do |file_name|
@@ -87,20 +87,7 @@ class Advent::CLITest < Advent::TestCase
     end
   end
 
-  def test_generate_solution_with_non_numbers_in_day
-    capture_io do
-      @year_cli.invoke(:generate, ["day3"])
-    end
-
-    ["day3.rb", "test/day3_test.rb"].each do |file_name|
-      expected_file_path = DUMMY_ROOT_PATH.join("2015", file_name)
-      assert File.exist? expected_file_path
-
-      File.delete expected_file_path
-    end
-  end
-
-  def test_generate_solution_valid_minimum_year
+  def test_generate_valid_minimum_year
     _out, err = capture_io do
       @cli.invoke(:generate, ["2013", "1"])
     end
@@ -108,15 +95,15 @@ class Advent::CLITest < Advent::TestCase
     assert_equal "Advent of Code only started in 2014!", err.strip
   end
 
-  def test_generate_solution_valid_maximum_year
+  def test_generate_valid_maximum_year
     _out, err = capture_io do
-      @cli.invoke(:generate, [Date.today.year + 1, "1"])
+      @cli.invoke(:generate, [(Date.today.year + 1).to_s, "1"])
     end
 
     assert_equal "Future years are not supported.", err.strip
   end
 
-  def test_generate_solution_valid_minimum_day
+  def test_generate_valid_minimum_day
     _out, err = capture_io do
       @cli.invoke(:generate, ["2015", "0"])
     end
@@ -124,7 +111,7 @@ class Advent::CLITest < Advent::TestCase
     assert_equal "Day must be between 1 and 25 (inclusive).", err.strip
   end
 
-  def test_generate_solution_valid_maximum_day
+  def test_generate_valid_maximum_day
     _out, err = capture_io do
       @cli.invoke(:generate, ["2015", "26"])
     end

--- a/test/advent/cli_test.rb
+++ b/test/advent/cli_test.rb
@@ -147,7 +147,7 @@ class Advent::CLITest < Advent::TestCase
     File.delete input if File.exist? input
   end
 
-  def test_not_asking_for_session_cookie
+  def test_not_asking_for_session_cookie_again
     Advent.session.value = @session
 
     out, _err = capture_io do

--- a/test/advent/cli_test.rb
+++ b/test/advent/cli_test.rb
@@ -35,6 +35,22 @@ class Advent::CLITest < Advent::TestCase
     Advent.session.clear
   end
 
+  def test_init
+    path = DUMMY_ROOT_PATH.join("init")
+    Dir.mkdir path
+
+    out, _err = capture_io do
+      Dir.chdir path do
+        @cli.invoke(:init)
+      end
+    end
+
+    assert_match(/create.*advent.yml/, out.strip)
+  ensure
+    File.delete path.join("advent.yml")
+    Dir.rmdir path
+  end
+
   def test_version
     out, _err = capture_io do
       @cli.invoke(:version)
@@ -85,7 +101,7 @@ class Advent::CLITest < Advent::TestCase
 
     assert File.exist? DUMMY_ROOT_PATH.join("2015", "day3.rb")
     assert File.exist? DUMMY_ROOT_PATH.join("2015", ".day3.input.txt")
-    
+
     File.delete DUMMY_ROOT_PATH.join("2015", "day3.rb")
     File.delete DUMMY_ROOT_PATH.join("2015", "test", "day3_test.rb")
     File.delete DUMMY_ROOT_PATH.join("2015", ".day3.input.txt")

--- a/test/advent/cli_test.rb
+++ b/test/advent/cli_test.rb
@@ -26,8 +26,12 @@ class Advent::CLITest < Advent::TestCase
       "day 5 input"
     )
 
-    @cli = Advent::CLI.new([], root_path: DUMMY_ROOT_PATH, http_module: http_mock)
-    @year_cli = Advent::CLI.new([], root_path: DUMMY_ROOT_PATH.join("2015"))
+    Dir.chdir DUMMY_ROOT_PATH
+    @cli = Advent::CLI.new([], http_module: http_mock)
+  end
+
+  def teardown
+    Dir.chdir DUMMY_ROOT_PATH
   end
 
   def test_version
@@ -38,7 +42,7 @@ class Advent::CLITest < Advent::TestCase
     assert_equal Advent::VERSION, out.strip
   end
 
-  def test_solve_from_parent_directory
+  def test_solve_from_root_directory
     out, _err = capture_io do
       @cli.invoke(:solve, ["2015/day1.rb"])
     end
@@ -48,7 +52,9 @@ class Advent::CLITest < Advent::TestCase
 
   def test_solve_from_year_directory
     out, _err = capture_io do
-      @year_cli.invoke(:solve, ["day2.rb"])
+      Dir.chdir DUMMY_ROOT_PATH.join("2015") do
+        @cli.invoke(:solve, ["day2.rb"])
+      end
     end
 
     assert_equal "Part 1: 789\nPart 2: Missing", out.strip

--- a/test/advent/cli_test.rb
+++ b/test/advent/cli_test.rb
@@ -74,6 +74,23 @@ class Advent::CLITest < Advent::TestCase
     end
   end
 
+  def test_download_when_generating
+    with_session("abc123") do
+      with_config({"download_when_generating" => true}) do
+        capture_io do
+          @cli.invoke(:generate, ["2015", "3"])
+        end
+      end
+    end
+
+    assert File.exist? DUMMY_ROOT_PATH.join("2015", "day3.rb")
+    assert File.exist? DUMMY_ROOT_PATH.join("2015", ".day3.input.txt")
+    
+    File.delete DUMMY_ROOT_PATH.join("2015", "day3.rb")
+    File.delete DUMMY_ROOT_PATH.join("2015", "test", "day3_test.rb")
+    File.delete DUMMY_ROOT_PATH.join("2015", ".day3.input.txt")
+  end
+
   def test_generate_day_parsing
     capture_io do
       @cli.invoke(:generate, ["2015", "day3"])

--- a/test/advent/configuration_test.rb
+++ b/test/advent/configuration_test.rb
@@ -18,6 +18,6 @@ class Advent::ConfigurationTest < Advent::TestCase
     config = Advent::Configuration.from_file(@config_file)
 
     refute config.download_when_generating
-    refute config.remember_session
+    assert config.remember_session
   end
 end

--- a/test/advent/configuration_test.rb
+++ b/test/advent/configuration_test.rb
@@ -7,8 +7,8 @@ class Advent::ConfigurationTest < Advent::TestCase
     @config_file = DUMMY_ROOT_PATH.join("advent.yml")
   end
 
-  def test_initializing_with_defaults
-    config = Advent::Configuration.new
+  def test_config_is_merged_with_defaults
+    config = Advent::Configuration.new({})
 
     assert config.download_when_generating
     assert config.remember_session

--- a/test/advent/configuration_test.rb
+++ b/test/advent/configuration_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Advent::ConfigurationTest < Advent::TestCase
+  def setup
+    @config_file = DUMMY_ROOT_PATH.join("advent.yml")
+  end
+
+  def test_initializing_with_defaults
+    config = Advent::Configuration.new
+
+    assert config.download_when_generating
+    assert config.remember_session
+  end
+
+  def test_initializing_from_file
+    config = Advent::Configuration.from_file(@config_file)
+
+    refute config.download_when_generating
+    refute config.remember_session
+  end
+end

--- a/test/advent/session_test.rb
+++ b/test/advent/session_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Advent::SessionTest < Advent::TestCase
   def setup
+    Dir.chdir DUMMY_ROOT_PATH
     @session = Advent::Session.new(name)
   end
 
@@ -24,6 +25,15 @@ class Advent::SessionTest < Advent::TestCase
   def test_setting_value
     @session.value = "session value"
     assert_equal "session value", File.read(@session.file_name)
+  end
+
+  def test_setting_value_honouring_config
+    with_config({"remember_session" => false}) do
+      @session.value = "session value"
+
+      assert_equal "session value", @session.value
+      refute @session.exist?
+    end
   end
 
   def test_value

--- a/test/advent_test.rb
+++ b/test/advent_test.rb
@@ -25,6 +25,12 @@ class TestAdvent < Advent::TestCase
     end
   end
 
+  def test_config_initialization
+    Dir.chdir DUMMY_ROOT_PATH do
+      assert_kind_of Advent::Configuration, Advent.config
+    end
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::Advent::VERSION
   end

--- a/test/advent_test.rb
+++ b/test/advent_test.rb
@@ -3,6 +3,28 @@
 require "test_helper"
 
 class TestAdvent < Advent::TestCase
+  def teardown
+    Dir.chdir DUMMY_ROOT_PATH
+  end
+
+  def test_finding_root_from_config_location
+    Dir.chdir DUMMY_ROOT_PATH do
+      assert_equal DUMMY_ROOT_PATH, Advent.root
+    end
+
+    Dir.chdir DUMMY_ROOT_PATH.join("2015") do
+      assert_equal DUMMY_ROOT_PATH, Advent.root
+    end
+
+    Dir.chdir DUMMY_ROOT_PATH.join("..") do
+      error = assert_raises Advent::Error do
+        Advent.root
+      end
+
+      assert_equal "Cannot find advent.yml config file in current or parent directories.", error.message
+    end
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::Advent::VERSION
   end

--- a/test/dummy/advent.yml
+++ b/test/dummy/advent.yml
@@ -1,0 +1,2 @@
+download_when_generating: false
+remember_session: false

--- a/test/dummy/advent.yml
+++ b/test/dummy/advent.yml
@@ -1,2 +1,2 @@
 download_when_generating: false
-remember_session: false
+remember_session: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,17 @@ require "minitest/autorun"
 DUMMY_ROOT_PATH = Pathname.new File.expand_path("dummy", __dir__)
 
 class Advent::TestCase < Minitest::Test
+  def with_config(config)
+    original_config = Advent.config
+
+    config_with_defaults = Advent::Configuration::DEFAULTS.merge(config)
+    Advent.instance_variable_set(:@_config, Advent::Configuration.new(config_with_defaults))
+
+    yield
+  ensure
+    Advent.instance_variable_set(:@_config, original_config)
+  end
+
   def with_session(value)
     Advent.session.value = value
     yield

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,13 @@ require "minitest/autorun"
 DUMMY_ROOT_PATH = Pathname.new File.expand_path("dummy", __dir__)
 
 class Advent::TestCase < Minitest::Test
+  def with_session(value)
+    Advent.session.value = value
+    yield
+  ensure
+    Advent.session.clear
+  end
+
   def with_stdin_input(input)
     require "stringio"
 


### PR DESCRIPTION
Closes #9 #10

Adds configuration to advent, and also a place to define the root of a "project". Breaking change as it now requires an `advent.yml` file to be present somewhere in the current or parent directory chain.